### PR TITLE
Upgrade Android Gradle build tools to 8.1.4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17]
+        java: [17]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 33
+    compileSdk 35
+    namespace "ai.elimu.analytics"
 
     defaultConfig {
         applicationId "ai.elimu.analytics"
@@ -34,6 +35,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 24 11:01:12 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 35
+    namespace "ai.elimu.analytics.utils"
 
     defaultConfig {
         minSdkVersion 24


### PR DESCRIPTION
* Update compileSdk to 35

### Issue Number
* Resolves #169, #170

### Purpose
* Upgrade Android Gradle build tools to 8.1.4
* Update compileSdk to 35
* Upgrade Java from 11 to 17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Android project setup to use a newer SDK version for enhanced performance and compatibility.
  - Updated the build tools and Gradle environment to the latest versions, ensuring a smoother and more reliable build process.
  - Improved build configurations to support more efficient and stable app deployments.
  - Introduced new namespaces for better organization of the application and its components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->