### PR TITLE
build: enable http

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <permission android:name="${applicationId}.provider.READ" />
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".BaseApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/ai/elimu/analytics/BaseApplication.java
+++ b/app/src/main/java/ai/elimu/analytics/BaseApplication.java
@@ -33,11 +33,11 @@ public class BaseApplication extends Application {
     }
 
     /**
-     * E.g. "https://hin.test.elimu.ai" or "https://hin.elimu.ai"
+     * E.g. "https://eng.elimu.ai" or "https://hin.elimu.ai"
      */
     public String getBaseUrl() {
         Language language = SharedPreferencesHelper.getLanguage(getApplicationContext());
-        String url = "https://" + language.getIsoCode();
+        String url = "http://" + language.getIsoCode();
         url += ".elimu.ai";
         return url;
     }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Temporarily enable `http` until SSL gets configured for the backend: https://github.com/elimu-ai/webapp/issues/1694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced network security settings that define how connections are handled, including managing certificate trust and cleartext traffic.
  - Updated network endpoint configuration to support revised connectivity behavior with improved examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->