### PR TITLE
Make Android ID visible when there are no events stored in the database

### DIFF
--- a/app/src/main/java/ai/elimu/analytics/MainActivity.kt
+++ b/app/src/main/java/ai/elimu/analytics/MainActivity.kt
@@ -1,6 +1,5 @@
 package ai.elimu.analytics
 
-import ai.elimu.analytics.db.RoomDb
 import ai.elimu.analytics.language.SelectLanguageActivity
 import ai.elimu.analytics.task.TaskInitializer
 import ai.elimu.analytics.util.SharedPreferencesHelper.getLanguage
@@ -44,23 +43,8 @@ class MainActivity : AppCompatActivity() {
 
             TaskInitializer.initializePeriodicWork(applicationContext)
 
-            // If the database is not empty, redirect the user to the EventListActivity
-            val roomDb = RoomDb.getDatabase(applicationContext)
-            val storyBookLearningEventDao = roomDb.storyBookLearningEventDao()
-            val wordLearningEventDao = roomDb.wordLearningEventDao()
-            RoomDb.databaseWriteExecutor.execute {
-                val wordLearningEvents =
-                    wordLearningEventDao.loadAllOrderedByTimeDesc()
-                Timber.i("wordLearningEvents.size(): %s", wordLearningEvents.size)
-
-                val storyBookLearningEvents =
-                    storyBookLearningEventDao.loadAll()
-                Timber.i("storyBookLearningEvents.size(): %s", storyBookLearningEvents.size)
-                if (storyBookLearningEvents.isNotEmpty()) {
-                    startActivity(Intent(applicationContext, EventListActivity::class.java))
-                    finish()
-                }
-            }
+            startActivity(Intent(applicationContext, EventListActivity::class.java))
+            finish()
         }
     }
 }


### PR DESCRIPTION
### Issue Number
* Resolves #305

### Purpose
Make Android ID visible when there are no events stored in the database

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
