### PR TITLE
Remove storage of `android_id column` from CSV exports

### DIFF
--- a/app/src/main/java/ai/elimu/analytics/task/ExportEventsToCsvWorker.kt
+++ b/app/src/main/java/ai/elimu/analytics/task/ExportEventsToCsvWorker.kt
@@ -50,7 +50,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
             .withHeader(
                 "id",
                 "timestamp",
-                "android_id",
                 "package_name",
                 "letter_sound_letters",
                 "letter_sound_sounds",
@@ -82,7 +81,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
                 csvPrinter.printRecord(
                     letterSoundAssessmentEvent.id,
                     letterSoundAssessmentEvent.time.timeInMillis,
-                    letterSoundAssessmentEvent.androidId,
                     letterSoundAssessmentEvent.packageName,
                     letterSoundAssessmentEvent.letterSoundLetters,
                     letterSoundAssessmentEvent.letterSoundSounds,
@@ -121,7 +119,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
             .withHeader(
                 "id",
                 "time",
-                "android_id",
                 "package_name",
                 "letter_sound_id",
                 "letter_sound_letter_texts",
@@ -153,7 +150,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
                 csvPrinter.printRecord(
                     letterSoundLearningEvent.id,
                     letterSoundLearningEvent.time.timeInMillis,
-                    letterSoundLearningEvent.androidId,
                     letterSoundLearningEvent.packageName,
                     letterSoundLearningEvent.id,
                     null,
@@ -189,7 +185,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
             .withHeader(
                 "id",
                 "time",
-                "android_id",
                 "package_name",
                 "word_id",
                 "word_text",
@@ -221,7 +216,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
                 csvPrinter.printRecord(
                     wordLearningEvent.id,
                     wordLearningEvent.time.timeInMillis,
-                    wordLearningEvent.androidId,
                     wordLearningEvent.packageName,
                     wordLearningEvent.wordId,
                     wordLearningEvent.wordText,
@@ -257,7 +251,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
             .withHeader(
                 "id",
                 "time",
-                "android_id",
                 "package_name",
                 "word_id",
                 "word_text",
@@ -290,7 +283,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
                 csvPrinter.printRecord(
                     wordAssessmentEvent.id,
                     wordAssessmentEvent.time.timeInMillis,
-                    wordAssessmentEvent.androidId,
                     wordAssessmentEvent.packageName,
                     wordAssessmentEvent.wordId,
                     wordAssessmentEvent.wordText,
@@ -327,7 +319,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
             .withHeader(
                 "id",
                 "time",
-                "android_id",
                 "package_name",
                 "storybook_title",
                 "storybook_id",
@@ -359,7 +350,6 @@ class ExportEventsToCsvWorker(context: Context, workerParams: WorkerParameters) 
                 csvPrinter.printRecord(
                     storyBookLearningEvent.id,
                     storyBookLearningEvent.time.timeInMillis,
-                    storyBookLearningEvent.androidId,
                     storyBookLearningEvent.packageName,
                     storyBookLearningEvent.storyBookTitle,
                     storyBookLearningEvent.storyBookId,


### PR DESCRIPTION
### Issue Number
* Resolves #302 

### Purpose
Remove storage of `android_id column` from CSV exports

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "android_id" column from CSV exports for all event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->