### PR TITLE
Make `additionalData` optional when reporting event

### DIFF
--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -25,7 +25,7 @@ object LearningEventUtil {
      */
     fun reportLetterSoundLearningEvent(
         letterSoundGson: LetterSoundGson,
-        additionalData: JSONObject,
+        additionalData: JSONObject?,
         context: Context,
         analyticsApplicationId: String?
     ) {
@@ -34,7 +34,9 @@ object LearningEventUtil {
         val broadcastIntent = Intent()
         broadcastIntent.setAction("ai.elimu.intent.action.LETTER_SOUND_LEARNING_EVENT")
         broadcastIntent.putExtra("packageName", context.packageName)
-        broadcastIntent.putExtra("additionalData", additionalData.toString())
+        additionalData?.let {
+            broadcastIntent.putExtra("additionalData", additionalData.toString())
+        }
         broadcastIntent.putExtra("letterSoundId", letterSoundGson.id)
         broadcastIntent.putExtra(
             "letterSoundLetterTexts",
@@ -64,7 +66,7 @@ object LearningEventUtil {
     fun reportWordLearningEvent(
         wordGson: WordGson,
         learningEventType: LearningEventType,
-        additionalData: JSONObject,
+        additionalData: JSONObject?,
         context: Context,
         analyticsApplicationId: String?
     ) {
@@ -73,7 +75,9 @@ object LearningEventUtil {
         val broadcastIntent = Intent()
         broadcastIntent.setAction("ai.elimu.intent.action.WORD_LEARNING_EVENT")
         broadcastIntent.putExtra("packageName", context.packageName)
-        broadcastIntent.putExtra("additionalData", additionalData.toString())
+        additionalData?.let {
+            broadcastIntent.putExtra("additionalData", additionalData.toString())
+        }
         broadcastIntent.putExtra("wordId", wordGson.id)
         broadcastIntent.putExtra("wordText", wordGson.text)
         broadcastIntent.putExtra("learningEventType", learningEventType.toString())
@@ -91,7 +95,7 @@ object LearningEventUtil {
     fun reportStoryBookLearningEvent(
         storyBookGson: StoryBookGson,
         learningEventType: LearningEventType,
-        additionalData: JSONObject,
+        additionalData: JSONObject?,
         context: Context,
         analyticsApplicationId: String?
     ) {
@@ -100,7 +104,9 @@ object LearningEventUtil {
         val broadcastIntent = Intent()
         broadcastIntent.setAction("ai.elimu.intent.action.STORYBOOK_LEARNING_EVENT")
         broadcastIntent.putExtra("packageName", context.packageName)
-        broadcastIntent.putExtra("additionalData", additionalData.toString())
+        additionalData?.let {
+            broadcastIntent.putExtra("additionalData", additionalData.toString())
+        }
         broadcastIntent.putExtra("storyBookTitle", storyBookGson.title)
         broadcastIntent.putExtra("storyBookId", storyBookGson.id)
         broadcastIntent.putExtra("learningEventType", learningEventType.toString())
@@ -118,7 +124,7 @@ object LearningEventUtil {
     fun reportVideoLearningEvent(
         videoGson: VideoGson,
         learningEventType: LearningEventType,
-        additionalData: JSONObject,
+        additionalData: JSONObject?,
         context: Context,
         analyticsApplicationId: String?
     ) {
@@ -127,7 +133,9 @@ object LearningEventUtil {
         val broadcastIntent = Intent()
         broadcastIntent.setAction("ai.elimu.intent.action.VIDEO_LEARNING_EVENT")
         broadcastIntent.putExtra("packageName", context.packageName)
-        broadcastIntent.putExtra("additionalData", additionalData.toString())
+        additionalData?.let {
+            broadcastIntent.putExtra("additionalData", additionalData.toString())
+        }
         broadcastIntent.putExtra("videoId", videoGson.id)
         broadcastIntent.putExtra("videoTitle", videoGson.title)
         broadcastIntent.putExtra("learningEventType", learningEventType.toString())


### PR DESCRIPTION
### Issue Number
* Resolves #323

### Purpose
Make `additionalData` optional when reporting event, to reduce boiler plate code when there's no need to include any extra data to a learning event report

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by ensuring that additional data is only included in learning event reports when available, preventing potential errors related to missing or null data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->