### PR TITLE
refactor: allow missing storybook id

### DIFF
--- a/app/schemas/ai.elimu.analytics.db.RoomDb/22.json
+++ b/app/schemas/ai.elimu.analytics.db.RoomDb/22.json
@@ -1,0 +1,575 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "7590e1363cca43a93a97661ffe894cae",
+    "entities": [
+      {
+        "tableName": "LetterSoundAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetters` TEXT NOT NULL, `letterSoundSounds` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "letterSoundLetters",
+            "columnName": "letterSoundLetters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundSounds",
+            "columnName": "letterSoundSounds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundId",
+            "columnName": "letterSoundId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LetterSoundLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetterTexts` TEXT NOT NULL, `letterSoundSoundValuesIpa` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "letterSoundLetterTexts",
+            "columnName": "letterSoundLetterTexts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundSoundValuesIpa",
+            "columnName": "letterSoundSoundValuesIpa",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundId",
+            "columnName": "letterSoundId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "WordAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wordText` TEXT NOT NULL, `wordId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "wordText",
+            "columnName": "wordText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordId",
+            "columnName": "wordId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "WordLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wordText` TEXT NOT NULL, `wordId` INTEGER, `learningEventType` TEXT, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "wordText",
+            "columnName": "wordText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordId",
+            "columnName": "wordId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "learningEventType",
+            "columnName": "learningEventType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "NumberAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`numberValue` INTEGER NOT NULL, `numberId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "numberValue",
+            "columnName": "numberValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberId",
+            "columnName": "numberId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "NumberLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`numberValue` INTEGER NOT NULL, `numberSymbol` TEXT, `numberId` INTEGER, `learningEventType` TEXT, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "numberValue",
+            "columnName": "numberValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberSymbol",
+            "columnName": "numberSymbol",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numberId",
+            "columnName": "numberId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "learningEventType",
+            "columnName": "learningEventType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "StoryBookLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storyBookTitle` TEXT NOT NULL, `storyBookId` INTEGER NOT NULL, `learningEventType` TEXT, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "storyBookTitle",
+            "columnName": "storyBookTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storyBookId",
+            "columnName": "storyBookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "learningEventType",
+            "columnName": "learningEventType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "VideoLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoTitle` TEXT NOT NULL, `videoId` INTEGER, `learningEventType` TEXT, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "videoTitle",
+            "columnName": "videoTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "learningEventType",
+            "columnName": "learningEventType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7590e1363cca43a93a97661ffe894cae')"
+    ]
+  }
+}

--- a/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
+++ b/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
@@ -31,7 +31,7 @@ import ai.elimu.analytics.entity.WordAssessmentEvent;
 import ai.elimu.analytics.entity.WordLearningEvent;
 import timber.log.Timber;
 
-@Database(version = 21, entities = {
+@Database(version = 22, entities = {
         LetterSoundAssessmentEvent.class,
         LetterSoundLearningEvent.class,
 


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #392

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
