### PR TITLE
refactor: add receiver for learning events and assessment events

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,13 @@
                 <action android:name="ai.elimu.intent.action.ANALYTICS_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.WordLearningEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.WORD_LEARNING_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.NumberAssessmentEventReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,13 @@
                 <action android:name="ai.elimu.intent.action.LETTER_SOUND_LEARNING_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.LetterSoundAssessmentEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.LETTER_SOUND_ASSESSMENT_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.WordLearningEventReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,13 @@
                 <action android:name="ai.elimu.intent.action.WORD_LEARNING_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.NumberLearningEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.NUMBER_LEARNING_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.NumberAssessmentEventReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,13 @@
                 <action android:name="ai.elimu.intent.action.NUMBER_ASSESSMENT_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.StoryBookLearningEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.VIDEO_LEARNING_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.VideoLearningEventReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,13 @@
                 <action android:name="ai.elimu.intent.action.NUMBER_ASSESSMENT_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.VideoLearningEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.VIDEO_LEARNING_EVENT" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:name=".provider.LetterSoundAssessmentEventProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,13 @@
                 <action android:name="ai.elimu.intent.action.ANALYTICS_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.LetterSoundLearningEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.LETTER_SOUND_LEARNING_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.WordLearningEventReceiver"
             android:enabled="true"
             android:exported="true">
@@ -71,7 +78,7 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="ai.elimu.intent.action.VIDEO_LEARNING_EVENT" />
+                <action android:name="ai.elimu.intent.action.STORYBOOK_LEARNING_EVENT" />
             </intent-filter>
         </receiver>
         <receiver android:name=".receiver.VideoLearningEventReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,13 @@
                 <action android:name="ai.elimu.intent.action.WORD_LEARNING_EVENT" />
             </intent-filter>
         </receiver>
+        <receiver android:name=".receiver.WordAssessmentEventReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="ai.elimu.intent.action.WORD_ASSESSMENT_EVENT" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".receiver.NumberLearningEventReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/java/ai/elimu/analytics/entity/NumberLearningEvent.kt
+++ b/app/src/main/java/ai/elimu/analytics/entity/NumberLearningEvent.kt
@@ -6,8 +6,8 @@ import androidx.room.Entity
  * Based on https://github.com/elimu-ai/webapp/blob/main/src/main/java/ai/elimu/entity/analytics/NumberLearningEvent.java
  */
 @Entity
-class NumberLearningEvent (val numberValue: Int) : LearningEvent() {
-    // TODO: numberValue
+class NumberLearningEvent : LearningEvent() {
+    var numberValue: Int = Int.MIN_VALUE
 
     var numberSymbol: String? = null
 

--- a/app/src/main/java/ai/elimu/analytics/enum/EventType.kt
+++ b/app/src/main/java/ai/elimu/analytics/enum/EventType.kt
@@ -230,13 +230,14 @@ fun EventType.createEventFromIntent(context: Context, intent: Intent): BaseEntit
 
             Timber.i("numberId: $numberId. hasKey NUMBER_ID: ${intent.hasExtra(BundleKeys.KEY_NUMBER_ID)}")
 
-            NumberLearningEvent(numberValue).apply {
+            NumberLearningEvent().apply {
                 this.timestamp = timestamp
                 this.androidId = androidId
                 this.packageName = packageName
                 this.additionalData = additionalData
                 this.researchExperiment = researchExperiment
                 this.experimentGroup = experimentGroup
+                this.numberValue = numberValue
                 this.numberSymbol = numberSymbol
                 this.numberId = numberId
             }

--- a/app/src/main/java/ai/elimu/analytics/receiver/LetterSoundLearningEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/LetterSoundLearningEventReceiver.kt
@@ -1,0 +1,78 @@
+package ai.elimu.analytics.receiver
+
+import ai.elimu.analytics.db.RoomDb
+import ai.elimu.analytics.entity.LetterSoundLearningEvent
+import ai.elimu.analytics.utils.BundleKeys
+import ai.elimu.analytics.utils.research.ExperimentAssignmentHelper
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.text.TextUtils
+import timber.log.Timber
+import java.util.Calendar
+
+class LetterSoundLearningEventReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.i("onReceive")
+
+        val bundle = intent.extras
+        bundle?.let {
+            for (key in bundle.keySet()) {
+                val value = bundle.get(key)
+                Timber.i("${key}=${value}")
+            }
+        }
+
+        try {
+            val event = LetterSoundLearningEvent()
+
+            val androidId: String = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            event.androidId = androidId
+
+            val packageName: String = intent.getStringExtra(BundleKeys.KEY_PACKAGE_NAME) ?: ""
+            if (TextUtils.isEmpty(packageName)) {
+                throw IllegalArgumentException("Missing packageName")
+            }
+            event.packageName = packageName
+
+            val timestamp: Calendar = Calendar.getInstance()
+            event.timestamp = timestamp
+
+            val researchExperiment = ExperimentAssignmentHelper.CURRENT_EXPERIMENT
+            event.researchExperiment = researchExperiment
+
+            val experimentGroup = ExperimentAssignmentHelper.getExperimentGroup(context)
+            event.experimentGroup = experimentGroup
+
+            val additionalData: String? = intent.getStringExtra(BundleKeys.KEY_ADDITIONAL_DATA)
+            event.additionalData = additionalData
+
+            val letterSoundLetters = intent.getStringArrayExtra(BundleKeys.KEY_LETTER_SOUND_LETTERS) ?: emptyArray()
+            Timber.i("letterSoundLetters: ${letterSoundLetters}")
+            // TODO: event.letterSoundLetters = letterSoundLetters
+
+            val letterSoundSounds = intent.getStringArrayExtra(BundleKeys.KEY_LETTER_SOUND_SOUNDS) ?: emptyArray()
+            Timber.i("letterSoundSounds: ${letterSoundSounds}")
+            // TODO: event.letterSoundSounds = letterSoundSounds
+
+            val letterSoundId: Long = intent.getLongExtra(BundleKeys.KEY_LETTER_SOUND_ID, 0)
+            if (letterSoundId > 0) {
+                event.letterSoundId = letterSoundId
+            }
+
+            // Store the event in the database
+            val roomDb = RoomDb.getDatabase(context)
+            RoomDb.databaseWriteExecutor.execute {
+                roomDb.letterSoundLearningEventDao().insert(event)
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            val results: Bundle = getResultExtras(true)
+            val errorMessage = e.message ?: e::class.simpleName
+            results.putString("errorMessage", errorMessage)
+        }
+    }
+}

--- a/app/src/main/java/ai/elimu/analytics/receiver/NumberAssessmentEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/NumberAssessmentEventReceiver.kt
@@ -68,6 +68,8 @@ class NumberAssessmentEventReceiver : BroadcastReceiver() {
             }
             event.numberValue = numberValue
 
+            // TODO: numberSymbol
+
             val numberId: Long = intent.getLongExtra(BundleKeys.KEY_NUMBER_ID, 0)
             if (numberId > 0) {
                 event.numberId = numberId

--- a/app/src/main/java/ai/elimu/analytics/receiver/NumberLearningEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/NumberLearningEventReceiver.kt
@@ -1,0 +1,79 @@
+package ai.elimu.analytics.receiver
+
+import ai.elimu.analytics.db.RoomDb
+import ai.elimu.analytics.entity.NumberLearningEvent
+import ai.elimu.analytics.utils.BundleKeys
+import ai.elimu.analytics.utils.research.ExperimentAssignmentHelper
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.text.TextUtils
+import timber.log.Timber
+import java.util.Calendar
+
+class NumberLearningEventReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.i("onReceive")
+
+        val bundle = intent.extras
+        bundle?.let {
+            for (key in bundle.keySet()) {
+                val value = bundle.get(key)
+                Timber.i("${key}=${value}")
+            }
+        }
+
+        try {
+            val event = NumberLearningEvent()
+
+            val androidId: String = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            event.androidId = androidId
+
+            val packageName: String = intent.getStringExtra(BundleKeys.KEY_PACKAGE_NAME) ?: ""
+            if (TextUtils.isEmpty(packageName)) {
+                throw IllegalArgumentException("Missing packageName")
+            }
+            event.packageName = packageName
+
+            val timestamp: Calendar = Calendar.getInstance()
+            event.timestamp = timestamp
+
+            val researchExperiment = ExperimentAssignmentHelper.CURRENT_EXPERIMENT
+            event.researchExperiment = researchExperiment
+
+            val experimentGroup = ExperimentAssignmentHelper.getExperimentGroup(context)
+            event.experimentGroup = experimentGroup
+
+            val additionalData: String? = intent.getStringExtra(BundleKeys.KEY_ADDITIONAL_DATA)
+            event.additionalData = additionalData
+
+            val numberValue: Int = intent.getIntExtra(BundleKeys.KEY_NUMBER_VALUE, Int.MIN_VALUE)
+            if (numberValue == Int.MIN_VALUE) {
+                throw IllegalArgumentException("Missing numberValue")
+            }
+            event.numberValue = numberValue
+
+            val numberSymbol: String? = intent.getStringExtra(BundleKeys.KEY_NUMBER_SYMBOL)
+            event.numberSymbol = numberSymbol
+
+            val numberId: Long = intent.getLongExtra(BundleKeys.KEY_NUMBER_ID, 0)
+            if (numberId > 0) {
+                event.numberId = numberId
+            }
+
+            // Store the event in the database
+            val roomDb = RoomDb.getDatabase(context)
+            RoomDb.databaseWriteExecutor.execute {
+                roomDb.numberLearningEventDao().insert(event)
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            val results: Bundle = getResultExtras(true)
+            val errorMessage = e.message ?: e::class.simpleName
+            results.putString("errorMessage", errorMessage)
+        }
+    }
+}

--- a/app/src/main/java/ai/elimu/analytics/receiver/StoryBookLearningEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/StoryBookLearningEventReceiver.kt
@@ -1,0 +1,76 @@
+package ai.elimu.analytics.receiver
+
+import ai.elimu.analytics.db.RoomDb
+import ai.elimu.analytics.entity.StoryBookLearningEvent
+import ai.elimu.analytics.utils.BundleKeys
+import ai.elimu.analytics.utils.research.ExperimentAssignmentHelper
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.text.TextUtils
+import timber.log.Timber
+import java.util.Calendar
+
+class StoryBookLearningEventReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.i("onReceive")
+
+        val bundle = intent.extras
+        bundle?.let {
+            for (key in bundle.keySet()) {
+                val value = bundle.get(key)
+                Timber.i("${key}=${value}")
+            }
+        }
+
+        try {
+            val event = StoryBookLearningEvent()
+
+            val androidId: String = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            event.androidId = androidId
+
+            val packageName: String = intent.getStringExtra(BundleKeys.KEY_PACKAGE_NAME) ?: ""
+            if (TextUtils.isEmpty(packageName)) {
+                throw IllegalArgumentException("Missing packageName")
+            }
+            event.packageName = packageName
+
+            val timestamp: Calendar = Calendar.getInstance()
+            event.timestamp = timestamp
+
+            val researchExperiment = ExperimentAssignmentHelper.CURRENT_EXPERIMENT
+            event.researchExperiment = researchExperiment
+
+            val experimentGroup = ExperimentAssignmentHelper.getExperimentGroup(context)
+            event.experimentGroup = experimentGroup
+
+            val additionalData: String? = intent.getStringExtra(BundleKeys.KEY_ADDITIONAL_DATA)
+            event.additionalData = additionalData
+
+            val storyBookTitle: String = intent.getStringExtra(BundleKeys.KEY_STORYBOOK_TITLE) ?: ""
+            if (TextUtils.isEmpty(storyBookTitle)) {
+                throw IllegalArgumentException("Missing storyBookTitle")
+            }
+            event.storyBookTitle = storyBookTitle
+
+            val storyBookId: Long = intent.getLongExtra(BundleKeys.KEY_STORYBOOK_ID, 0)
+            if (storyBookId > 0) {
+                event.storyBookId = storyBookId
+            }
+
+            // Store the event in the database
+            val roomDb = RoomDb.getDatabase(context)
+            RoomDb.databaseWriteExecutor.execute {
+                roomDb.storyBookLearningEventDao().insert(event)
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            val results: Bundle = getResultExtras(true)
+            val errorMessage = e.message ?: e::class.simpleName
+            results.putString("errorMessage", errorMessage)
+        }
+    }
+}

--- a/app/src/main/java/ai/elimu/analytics/receiver/VideoLearningEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/VideoLearningEventReceiver.kt
@@ -1,0 +1,76 @@
+package ai.elimu.analytics.receiver
+
+import ai.elimu.analytics.db.RoomDb
+import ai.elimu.analytics.entity.VideoLearningEvent
+import ai.elimu.analytics.utils.BundleKeys
+import ai.elimu.analytics.utils.research.ExperimentAssignmentHelper
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.text.TextUtils
+import timber.log.Timber
+import java.util.Calendar
+
+class VideoLearningEventReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.i("onReceive")
+
+        val bundle = intent.extras
+        bundle?.let {
+            for (key in bundle.keySet()) {
+                val value = bundle.get(key)
+                Timber.i("${key}=${value}")
+            }
+        }
+
+        try {
+            val event = VideoLearningEvent()
+
+            val androidId: String = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            event.androidId = androidId
+
+            val packageName: String = intent.getStringExtra(BundleKeys.KEY_PACKAGE_NAME) ?: ""
+            if (TextUtils.isEmpty(packageName)) {
+                throw IllegalArgumentException("Missing packageName")
+            }
+            event.packageName = packageName
+
+            val timestamp: Calendar = Calendar.getInstance()
+            event.timestamp = timestamp
+
+            val researchExperiment = ExperimentAssignmentHelper.CURRENT_EXPERIMENT
+            event.researchExperiment = researchExperiment
+
+            val experimentGroup = ExperimentAssignmentHelper.getExperimentGroup(context)
+            event.experimentGroup = experimentGroup
+
+            val additionalData: String? = intent.getStringExtra(BundleKeys.KEY_ADDITIONAL_DATA)
+            event.additionalData = additionalData
+
+            val videoTitle: String = intent.getStringExtra(BundleKeys.KEY_VIDEO_TITLE) ?: ""
+            if (TextUtils.isEmpty(videoTitle)) {
+                throw IllegalArgumentException("Missing videoTitle")
+            }
+            event.videoTitle = videoTitle
+
+            val videoId: Long = intent.getLongExtra(BundleKeys.KEY_VIDEO_ID, 0)
+            if (videoId > 0) {
+                event.videoId = videoId
+            }
+
+            // Store the event in the database
+            val roomDb = RoomDb.getDatabase(context)
+            RoomDb.databaseWriteExecutor.execute {
+                roomDb.videoLearningEventDao().insert(event)
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            val results: Bundle = getResultExtras(true)
+            val errorMessage = e.message ?: e::class.simpleName
+            results.putString("errorMessage", errorMessage)
+        }
+    }
+}

--- a/app/src/main/java/ai/elimu/analytics/receiver/WordLearningEventReceiver.kt
+++ b/app/src/main/java/ai/elimu/analytics/receiver/WordLearningEventReceiver.kt
@@ -1,0 +1,76 @@
+package ai.elimu.analytics.receiver
+
+import ai.elimu.analytics.db.RoomDb
+import ai.elimu.analytics.entity.WordLearningEvent
+import ai.elimu.analytics.utils.BundleKeys
+import ai.elimu.analytics.utils.research.ExperimentAssignmentHelper
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.text.TextUtils
+import timber.log.Timber
+import java.util.Calendar
+
+class WordLearningEventReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.i("onReceive")
+
+        val bundle = intent.extras
+        bundle?.let {
+            for (key in bundle.keySet()) {
+                val value = bundle.get(key)
+                Timber.i("${key}=${value}")
+            }
+        }
+
+        try {
+            val event = WordLearningEvent()
+
+            val androidId: String = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            event.androidId = androidId
+
+            val packageName: String = intent.getStringExtra(BundleKeys.KEY_PACKAGE_NAME) ?: ""
+            if (TextUtils.isEmpty(packageName)) {
+                throw IllegalArgumentException("Missing packageName")
+            }
+            event.packageName = packageName
+
+            val timestamp: Calendar = Calendar.getInstance()
+            event.timestamp = timestamp
+
+            val researchExperiment = ExperimentAssignmentHelper.CURRENT_EXPERIMENT
+            event.researchExperiment = researchExperiment
+
+            val experimentGroup = ExperimentAssignmentHelper.getExperimentGroup(context)
+            event.experimentGroup = experimentGroup
+
+            val additionalData: String? = intent.getStringExtra(BundleKeys.KEY_ADDITIONAL_DATA)
+            event.additionalData = additionalData
+
+            val wordText: String = intent.getStringExtra(BundleKeys.KEY_WORD_TEXT) ?: ""
+            if (TextUtils.isEmpty(wordText)) {
+                throw IllegalArgumentException("Missing wordText")
+            }
+            event.wordText = wordText
+
+            val wordId: Long = intent.getLongExtra(BundleKeys.KEY_NUMBER_ID, 0)
+            if (wordId > 0) {
+                event.wordId = wordId
+            }
+
+            // Store the event in the database
+            val roomDb = RoomDb.getDatabase(context)
+            RoomDb.databaseWriteExecutor.execute {
+                roomDb.wordLearningEventDao().insert(event)
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            val results: Bundle = getResultExtras(true)
+            val errorMessage = e.message ?: e::class.simpleName
+            results.putString("errorMessage", errorMessage)
+        }
+    }
+}

--- a/utils/src/main/java/ai/elimu/analytics/utils/AssessmentEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/AssessmentEventUtil.kt
@@ -86,8 +86,7 @@ object AssessmentEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(LearningEventUtil.BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.WORD_ASSESSMENT.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.WORD_ASSESSMENT_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             broadcastIntent.putExtra(BundleKeys.KEY_MASTERY_SCORE, masteryScore)
             broadcastIntent.putExtra(BundleKeys.KEY_TIME_SPENT_MS, timeSpentMs)

--- a/utils/src/main/java/ai/elimu/analytics/utils/AssessmentEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/AssessmentEventUtil.kt
@@ -1,19 +1,15 @@
 package ai.elimu.analytics.utils
 
 import ai.elimu.analytics.utils.receiver.ErrorResultReceiver
-import ai.elimu.model.v2.gson.content.LetterGson
 import ai.elimu.model.v2.gson.content.LetterSoundGson
 import ai.elimu.model.v2.gson.content.NumberGson
-import ai.elimu.model.v2.gson.content.SoundGson
 import ai.elimu.model.v2.gson.content.WordGson
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import org.json.JSONObject
-import java.util.stream.Collectors
 
 /**
  * A utility class that makes it easier for other apps to report assessments events to the receivers
@@ -42,18 +38,24 @@ object AssessmentEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(LearningEventUtil.BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.LETTER_SOUND_ASSESSMENT.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.LETTER_SOUND_ASSESSMENT_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             broadcastIntent.putExtra(BundleKeys.KEY_MASTERY_SCORE, masteryScore)
             broadcastIntent.putExtra(BundleKeys.KEY_TIME_SPENT_MS, timeSpentMs)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())
             }
-            broadcastIntent.putExtra(BundleKeys.KEY_LETTER_SOUND_LETTERS,
-                letterSoundGson.letters.stream().map(LetterGson::getText).collect(Collectors.joining()))
-            broadcastIntent.putExtra(BundleKeys.KEY_LETTER_SOUND_SOUNDS,
-                letterSoundGson.sounds.stream().map(SoundGson::getValueIpa).collect(Collectors.joining()))
+
+            val letterSoundLetters: ArrayList<String> = ArrayList(
+                letterSoundGson.letters.map { it.text }
+            )
+            broadcastIntent.putStringArrayListExtra(BundleKeys.KEY_LETTER_SOUND_LETTERS, letterSoundLetters)
+
+            val letterSoundSounds: ArrayList<String> = ArrayList(
+                letterSoundGson.sounds.map { it.valueIpa }
+            )
+            broadcastIntent.putStringArrayListExtra(BundleKeys.KEY_LETTER_SOUND_SOUNDS, letterSoundSounds)
+
             letterSoundGson.id?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_LETTER_SOUND_ID, letterSoundGson.id)
             }

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -47,16 +47,15 @@ object LearningEventUtil {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())
             }
 
-            broadcastIntent.putExtra(
-                BundleKeys.KEY_LETTER_SOUND_LETTER_TEXTS,
-                letterSoundGson.letters.stream().map { obj: LetterGson -> obj.text }
-                    .collect(Collectors.toList()).toTypedArray()
+            val letterSoundLetters: ArrayList<String> = ArrayList(
+                letterSoundGson.letters.map { it.text }
             )
+            broadcastIntent.putStringArrayListExtra(BundleKeys.KEY_LETTER_SOUND_LETTERS, letterSoundLetters)
 
-            val letterSoundSoundValuesIpa = letterSoundGson.sounds.stream().map {
-                obj: SoundGson -> obj.valueIpa
-            }.collect(Collectors.toList()).toTypedArray()
-            broadcastIntent.putExtra(BundleKeys.KEY_LETTER_SOUND_SOUND_VALUES_IPA, letterSoundSoundValuesIpa)
+            val letterSoundSounds: ArrayList<String> = ArrayList(
+                letterSoundGson.sounds.map { it.valueIpa }
+            )
+            broadcastIntent.putStringArrayListExtra(BundleKeys.KEY_LETTER_SOUND_SOUNDS, letterSoundSounds)
 
             letterSoundGson.id?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_LETTER_SOUND_ID, letterSoundGson.id)

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -121,8 +121,7 @@ object LearningEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.STORYBOOK_LEARNING.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.STORYBOOK_LEARNING_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -41,8 +41,7 @@ object LearningEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.LETTER_SOUND_LEARNING.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.LETTER_SOUND_LEARNING_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -156,8 +156,7 @@ object LearningEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.VIDEO_LEARNING.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.VIDEO_LEARNING_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -87,8 +87,7 @@ object LearningEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.WORD_LEARNING.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.WORD_LEARNING_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())

--- a/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
+++ b/utils/src/main/java/ai/elimu/analytics/utils/LearningEventUtil.kt
@@ -191,8 +191,7 @@ object LearningEventUtil {
         try {
             val broadcastIntent = Intent()
             broadcastIntent.setPackage(analyticsApplicationId)
-            broadcastIntent.setAction(BROADCAST_INTENT_ACTION_ANALYTICS)
-            broadcastIntent.putExtra("intent_action", IntentAction.NUMBER_LEARNING.action)
+            broadcastIntent.setAction("ai.elimu.intent.action.NUMBER_LEARNING_EVENT")
             broadcastIntent.putExtra(BundleKeys.KEY_PACKAGE_NAME, context.packageName)
             additionalData?.let {
                 broadcastIntent.putExtra(BundleKeys.KEY_ADDITIONAL_DATA, additionalData.toString())


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
