### PR TITLE
feat: pass letters and sounds as string array extra to receivers

### DIFF
--- a/app/schemas/ai.elimu.analytics.db.RoomDb/24.json
+++ b/app/schemas/ai.elimu.analytics.db.RoomDb/24.json
@@ -1,0 +1,554 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "260cf9fe845bb116ec4ae0756471f0f6",
+    "entities": [
+      {
+        "tableName": "LetterSoundAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetters` TEXT NOT NULL, `letterSoundSounds` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "letterSoundLetters",
+            "columnName": "letterSoundLetters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundSounds",
+            "columnName": "letterSoundSounds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundId",
+            "columnName": "letterSoundId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LetterSoundLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetterTexts` TEXT NOT NULL, `letterSoundSoundValuesIpa` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "letterSoundLetterTexts",
+            "columnName": "letterSoundLetterTexts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundSoundValuesIpa",
+            "columnName": "letterSoundSoundValuesIpa",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundId",
+            "columnName": "letterSoundId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "WordAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wordText` TEXT NOT NULL, `wordId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "wordText",
+            "columnName": "wordText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordId",
+            "columnName": "wordId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "WordLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wordText` TEXT NOT NULL, `wordId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "wordText",
+            "columnName": "wordText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordId",
+            "columnName": "wordId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "NumberAssessmentEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`numberValue` INTEGER NOT NULL, `numberId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `time` INTEGER NOT NULL, `masteryScore` REAL NOT NULL, `timeSpentMs` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "numberValue",
+            "columnName": "numberValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberId",
+            "columnName": "numberId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "masteryScore",
+            "columnName": "masteryScore",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSpentMs",
+            "columnName": "timeSpentMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "NumberLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`numberValue` INTEGER NOT NULL, `numberSymbol` TEXT, `numberId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "numberValue",
+            "columnName": "numberValue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberSymbol",
+            "columnName": "numberSymbol",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numberId",
+            "columnName": "numberId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "StoryBookLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storyBookTitle` TEXT NOT NULL, `storyBookId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "storyBookTitle",
+            "columnName": "storyBookTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storyBookId",
+            "columnName": "storyBookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "VideoLearningEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoTitle` TEXT NOT NULL, `videoId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "videoTitle",
+            "columnName": "videoTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "androidId",
+            "columnName": "androidId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalData",
+            "columnName": "additionalData",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "researchExperiment",
+            "columnName": "researchExperiment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "experimentGroup",
+            "columnName": "experimentGroup",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '260cf9fe845bb116ec4ae0756471f0f6')"
+    ]
+  }
+}

--- a/app/schemas/ai.elimu.analytics.db.RoomDb/24.json
+++ b/app/schemas/ai.elimu.analytics.db.RoomDb/24.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 24,
-    "identityHash": "260cf9fe845bb116ec4ae0756471f0f6",
+    "identityHash": "b0adaf49bc73b3130150b7f090d67518",
     "entities": [
       {
         "tableName": "LetterSoundAssessmentEvent",
@@ -85,7 +85,7 @@
       },
       {
         "tableName": "LetterSoundLearningEvent",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetterTexts` TEXT NOT NULL, `letterSoundSoundValuesIpa` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`letterSoundLetterTexts` TEXT NOT NULL, `letterSoundSoundValuesIpa` TEXT NOT NULL, `letterSoundLetters` TEXT NOT NULL, `letterSoundSounds` TEXT NOT NULL, `letterSoundId` INTEGER, `androidId` TEXT NOT NULL, `packageName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `additionalData` TEXT, `researchExperiment` TEXT, `experimentGroup` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
         "fields": [
           {
             "fieldPath": "letterSoundLetterTexts",
@@ -96,6 +96,18 @@
           {
             "fieldPath": "letterSoundSoundValuesIpa",
             "columnName": "letterSoundSoundValuesIpa",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundLetters",
+            "columnName": "letterSoundLetters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "letterSoundSounds",
+            "columnName": "letterSoundSounds",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -548,7 +560,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '260cf9fe845bb116ec4ae0756471f0f6')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b0adaf49bc73b3130150b7f090d67518')"
     ]
   }
 }

--- a/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
+++ b/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
@@ -23,6 +23,7 @@ import ai.elimu.analytics.dao.VideoLearningEventDao;
 import ai.elimu.analytics.dao.WordAssessmentEventDao;
 import ai.elimu.analytics.dao.WordLearningEventDao;
 import ai.elimu.analytics.db.migration.AutoMigrationSpecFrom22To23;
+import ai.elimu.analytics.db.util.StringListConverter;
 import ai.elimu.analytics.entity.LetterSoundAssessmentEvent;
 import ai.elimu.analytics.entity.LetterSoundLearningEvent;
 import ai.elimu.analytics.entity.NumberAssessmentEvent;
@@ -47,7 +48,7 @@ import timber.log.Timber;
 
         VideoLearningEvent.class
 }, autoMigrations = {@AutoMigration(from = 22, to = 23, spec = AutoMigrationSpecFrom22To23.class)})
-@TypeConverters({Converters.class})
+@TypeConverters({Converters.class, StringListConverter.class})
 public abstract class RoomDb extends RoomDatabase {
     public abstract LetterSoundAssessmentEventDao letterSoundAssessmentEventDao();
     public abstract LetterSoundLearningEventDao letterSoundLearningEventDao();

--- a/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
+++ b/app/src/main/java/ai/elimu/analytics/db/RoomDb.java
@@ -33,7 +33,7 @@ import ai.elimu.analytics.entity.WordAssessmentEvent;
 import ai.elimu.analytics.entity.WordLearningEvent;
 import timber.log.Timber;
 
-@Database(version = 23, entities = {
+@Database(version = 24, entities = {
         LetterSoundAssessmentEvent.class,
         LetterSoundLearningEvent.class,
 

--- a/app/src/main/java/ai/elimu/analytics/db/util/StringListConverter.kt
+++ b/app/src/main/java/ai/elimu/analytics/db/util/StringListConverter.kt
@@ -1,0 +1,15 @@
+package ai.elimu.analytics.db.util
+
+import androidx.room.TypeConverter
+
+class StringListConverter {
+    @TypeConverter
+    fun fromString(stringListString: String): List<String> {
+        return stringListString.split(",").map { it }
+    }
+
+    @TypeConverter
+    fun toString(stringList: List<String>): String {
+        return stringList.joinToString(separator = ",")
+    }
+}

--- a/app/src/main/java/ai/elimu/analytics/entity/LetterSoundLearningEvent.kt
+++ b/app/src/main/java/ai/elimu/analytics/entity/LetterSoundLearningEvent.kt
@@ -7,9 +7,21 @@ import androidx.room.Entity
  */
 @Entity
 class LetterSoundLearningEvent : LearningEvent() {
+    @Deprecated("Will be replaced by `letterSoundLetters`")
     lateinit var letterSoundLetterTexts: Array<String>
 
+    @Deprecated("Will be replaced by `letterSoundSounds`")
     lateinit var letterSoundSoundValuesIpa: Array<String>
+
+    /**
+     * The sequence of letters. E.g. `["s","h"]`.
+     */
+    lateinit var letterSoundLetters: List<String>
+
+    /**
+     *  The sequence of sounds (IPA values). E.g. `["ʃ"]`.
+     */
+    lateinit var letterSoundSounds: List<String>
 
     /**
      * This field might not be included, e.g. if the event occurred in a 3rd-party app that did not


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #405

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
